### PR TITLE
Notes from Paul + few fixes

### DIFF
--- a/_posts/2014-04-01-updated-gdc-roundtable-notes.md
+++ b/_posts/2014-04-01-updated-gdc-roundtable-notes.md
@@ -11,8 +11,8 @@ categories:
 ---
 I have updated my notes from the GDC roundtables. They should now be a little more useful for both attendees and those that missed out. Enjoy!
 
-[Day 1 Notes](http://thetoolsmiths.org/2014/03/19/technical-issues-in-tools-day-1/)
+[Day 1 Notes]({{site.url}}{%- link _posts/2014-03-19-technical-issues-in-tools-day-1.md %})
 
-[Day 2 Notes](http://thetoolsmiths.org/2014/03/23/technical-issues-in-tools-day-2/)
+[Day 2 Notes]({{site.url}}{%- link _posts/2014-03-19-technical-issues-in-tools-day-2.md %})
 
-[Day 3 Notes](http://thetoolsmiths.org/2014/03/23/technical-issues-in-tools-day-3/)
+[Day 3 Notes]({{site.url}}{%- link _posts/2014-03-19-technical-issues-in-tools-day-3.md %})

--- a/codex/gdc/roundtable/2018/technical-issues-in-tools-development-roundtable-day-1.md
+++ b/codex/gdc/roundtable/2018/technical-issues-in-tools-development-roundtable-day-1.md
@@ -1,0 +1,68 @@
+---
+title: 'Technical Issues in Tools Development Roundtable - Day 1: Process'
+layout: codex_page
+author: Paul Haile
+permalink: /codex/gdc/roundtable/2018/day-1
+nav_tag: gdc
+---
+{% include JB/setup %}
+
+Brainstorm Topics:  Storing Source Assets, Git+P4 Interop, Metadata/Asset Tagging, CI for Unity, Tool Deployment to Users, Engineer vs. Content Creator Segregation, Distributed Team Workflows
+
+Source Assets:
+  - Storing source assets directly in perforce seems to be the most common solution.
+    - Be smart about client specs and stream specs to minimize unecessary data.  By dicipline works well.
+    - Add +S (purge flag) on intermediate data.
+    - Scaling doesnt seem to be a problem here - P4 handles massive files with no issues - provided you have a strong enough infrastucture (storage / networking)
+    - Use proxies when possible to get files closer to the people syncing them.  They're cheap and easy to set up.
+
+
+Git+P4 Interop:
+  - Content creators using P4 but engineers using Git, what are good ways to interop between these?
+    - Most common answer: get your engineers to switch to P4.
+  - Git Fusion is a thing Perforce is working on:  <https://www.perforce.com/video-tutorials/git-fusion-overview>
+  - Engineers can use Git and you can have your build system submit artifacts into P4 for content creator use.
+  - Microsoft migrated to Git recently, and even with GitVFS needed additional fast HDD space installed for everyone to handle.
+  - GitLFS and Git-P4 other options out there.
+
+
+Asset Metadata / Tagging & Searching:
+  - Implement a tagging policy within the studio and enforce it with the tooling.
+    - Only allow set tags to be used, can't just type in arbitrary tags.
+    - Make sure ap rocess exists for users to come up with new tags so the tags can evolve with the assets, but with some oversight and agreement on the actual tag names.
+  - Legal Approval Pipelines?  How do people track state?
+    - Some use excel, but have issues with assets becoming "unapproved"
+    - Jira or any defect tracker seems like a good solution - an asset becoming "unapproved" is a workflow state change - easy to track.
+
+
+CI for Unity Projects:
+  - Jenkins most common solution.
+    - Use linux, not windows for your workers.
+    - Notifications from Jenkins can go into Slack with a plugin.  Seems nice.
+    - Be careful of plugin creep bogging down your installation or causing conflicts. 
+  - TeamCity also has some support in the room but not as much as Jenkins.
+
+
+Tool Deployment:
+  - General strategy for most seems to revolve around some flavor of jamming tools into Perforce and distribute to users via syncing.
+    - Some use labels to provide different sets of the tools to different users.
+  - Some keep multiple copies of the tools locally and toggle them by munging PATH
+  - Gradle package manager came up - <https://gradle.org/>
+  - Some use an in house custom deployment manager, manifests per-project which describe the environment and tools to deploy.
+    - Some cautioned that if you use a custom tool deployment scheme make sure you support rollback and also have an update path for the updater itself.
+
+
+Engineer vs. Content Creator Segregation:
+  - Generally this discussion boiled down to a shout out to the talk I gave on Monday on this exact topic.
+    - Short answer:  Use branches and establish a release process.  
+    - Slides available here:  <https://twitter.com/Tyrael/status/977681346205134848>
+    - Not posted up on the Vault yet as of this writing, but the talk is named "Shipping Call of Duty" by Paul Haile
+
+
+Distributed Teams:
+  - P4 Proxy vs. Edge servers.  Most are seeming to land on Edges.
+  - Some use dependency graphs to sparse sync files only as needed when developers attempt to open files in their tools.  Syncs only what is absolutely necessary for them to work.
+  - Had a quick aside about outsourced resources specifically:
+    - Policies seem to very wildly here.  Some allow direct P4 access, but it seemed that most do not and instead have an ingestion process for the incoming assets.
+    - Some packaged in some tools for outsourcers to validate content on their end for the engine so they can do some rudimentary testing before sending back to the studio.
+

--- a/codex/gdc/roundtable/2018/technical-issues-in-tools-development-roundtable-day-2.md
+++ b/codex/gdc/roundtable/2018/technical-issues-in-tools-development-roundtable-day-2.md
@@ -1,0 +1,46 @@
+---
+title: 'Technical Issues in Tools Development Roundtable - Day 2: Assets'
+layout: codex_page
+author: Paul Haile
+permalink: /codex/gdc/roundtable/2018/day-2
+nav_tag: gdc
+---
+Brainstorm Topics:  Asset Loading / Streaming, Asset Caching / Build Result Sharing, Asset Indirection / Renaming / Referencing Schemes, Sharing Assets Between Projects
+
+Asset Loading / Streaming:
+  - Best to use multiple loading schemes at the same time.
+    - Generally rely on streaming assets in as needed, but also with a prioritization scheme, so high priority assets can jump the queue.
+    - Also support a hard load scheme when certain assets must be available before the player continues - like UI.
+
+
+Asset Caching:
+  - Content Addressible Storage commonly used.
+  - Most have HTTP caches over the top to serve assets as needed.
+  - Race local CPU resources with cache retrevial so if cache is unavailable or slow local CPU keeps build moving along.
+  - Cache warming / locating cache servers at your remote offices is always good.
+  - Consider 2 caching schemes, based on file size.  Large files can be transferred as is, but you may want to treat bulk small files differently to increase throughput.
+  - Rack a cache server along side your build farm to reduce latency.
+
+
+Asset Sharing Between Projects:
+  - Give art department robust search and migration tools and let them handle it.  
+
+
+Metadata/Indirection/References:
+  - DB backing, assign GUID / UUID to leaf assets.
+    - Consider storing ID along with last known location so you can recover / lazily update.
+
+
+Sparse Syncs:
+  - Commonly accepted solution to this is to store only a full dependency tree / metadata for the assets locally.  As users attempt to open/edit files sparse sync down what is necessary.
+
+
+Distribution:
+  - SN-DBS everywhere.  Use it for anything - its a great tool.
+  - Some use a build farm with a labeling scheme to prevent users from syncing asset changes that dont have cache warmed / build results available.
+  - Incredibuild also being used by several folks.
+
+
+Global Optimization:
+  - 2 pipelines seem to be the norm, quick iteration with little-to-no global optimization, with the understanding content creators may not be seeing an exact 1-to-1 representation in game, and a fully global optimized path that mostly only QA sees.  
+

--- a/codex/gdc/roundtable/2018/technical-issues-in-tools-development-roundtable-day-3.md
+++ b/codex/gdc/roundtable/2018/technical-issues-in-tools-development-roundtable-day-3.md
@@ -1,0 +1,52 @@
+---
+title: 'Technical Issues in Tools Development Roundtable - Day 3: Editors'
+layout: codex_page
+author: Paul Haile
+permalink: /codex/gdc/roundtable/2018/day-3
+nav_tag: gdc
+---
+Brainstorm Topics:  In-Engine vs. Outside App for Level Editors, Visual Script Editor Organization, Undo Stack for Multi-Editor Development, Tools Diagnostics, Survey: Dedicated Tools UX Designers, Telemetry, Small One-off Tools, Better 1st Party Tooling, Discoverability
+
+
+In-engine vs. Outside Tool Level Editors:
+  - In-Engine editors really get you closer to seeing direct results.
+    - Downside is game instability = editor instability.  
+  - Some mix both of these with a common service layer in between actually holding the marbles.
+
+
+Visual Scripting:
+  - Try to reduce complexity of actual scripting system to reduce visual compexity in the editor.  Bundle common sets of actions into a single node.
+  - Some have created node graph diffing tools that work via image overlay on the node graph.  
+    - Underlying format in this case was XML and was difficult to parse in a diff, so the diffing tool was necessary.
+  - Some have visual scripting as a light wrapper around an internal text-based scripting language.  Solves diffing problem as you are saving out in your scripting language.
+  - Sub-graphs are a necessity for keeping things organized.
+
+
+Undo Queues:
+  - Always implement undo to behave as external editors undo works (Maya, Photoshop, etc.) - users will expect it to behave the same way.  
+  - Someone mentioned an Our Machinery article on Undo but I wasnt able to find it to link here.
+
+
+Diagnostics:
+  - Make extensive use of remote logging, pipe to ELK stack for easy searchability.
+  - Enable windows registry settings to catch any exception and send the dump to a network share for later analysis.
+
+
+Telemetry:
+  - Avoid drowning in data by having a mechanism for filtering what data users send up, or even which users send data.
+  - Always consider privacy implications in your data collection policies if your tool is used publically.  (GDPR!)
+  - Auto generated reports help draw attention to key points in your data collection quickly so you dont have to sift through it.
+
+
+1st Party Tooling:
+  - Difficult topic - cross platform nature of most franchises mean we always fall to the lowest common denominator of available features.
+
+
+Small One-Off Tools:
+  - ImGui / Synergy integration with your in-game tools is neat.
+  - A tool for quickly replaying debug commands to the console from the PC is useful.  QA likes it.
+
+
+Discoverability:
+  - Contextual in-place UI helps users find features related to the action they are doing at that moment.  
+  - Many use ambassadors / advocates per-dicipline to spread the word and educate.

--- a/codex/gdc/roundtable/sessions.md
+++ b/codex/gdc/roundtable/sessions.md
@@ -7,7 +7,17 @@ nav_tag: gdc
 ---
 {% include JB/setup %}
 
-#### [Tools Roundtable Notes @ GDC 2007 ](https://web.archive.org/web/20081011034025/http://www.igda.org/wiki/GDC_2007_-_Tools_Roundtable_Notes)
+#### Tools Roundtable Notes @ GDC 2018
+##### by Paul Haile‏  [Day 1]({{site.url}}{%- link codex/gdc/roundtable/2018/technical-issues-in-tools-development-roundtable-day-1.md -%}) | [Day 2]({{site.url}}{%- link codex/gdc/roundtable/2018/technical-issues-in-tools-development-roundtable-day-2.md -%}) | [Day 3]({{site.url}}{%- link codex/gdc/roundtable/2018/technical-issues-in-tools-development-roundtable-day-3.md -%})
+
+------
+
+#### Tools Roundtable Notes @ GDC 2017
+##### by Paul Haile‏  [Day 1](https://twitter.com/Tyrael/status/837368231752970240) | [Day 2](https://twitter.com/Tyrael/status/837704456888287232) | [Day 3](https://twitter.com/Tyrael/status/838875803353927681)
+
+------
+
+#### [Tools Roundtable Notes @ GDC 2014]({{ site.baseurl }}{%- link _posts/2014-04-01-updated-gdc-roundtable-notes.md -%})
 
 ------
 
@@ -16,11 +26,6 @@ nav_tag: gdc
 
 ------
 
-#### [Tools Roundtable Notes @ GDC 2014]({{ site.baseurl }}/2014/04/01/updated-gdc-roundtable-notes/)
-
-------
-
-#### Tools Roundtable Notes @ GDC 2017
-##### by Paul Haile‏  [Day 1](https://twitter.com/Tyrael/status/837368231752970240) | [Day 2](https://twitter.com/Tyrael/status/837704456888287232) | [Day 3](https://twitter.com/Tyrael/status/838875803353927681)
+#### [Tools Roundtable Notes @ GDC 2007 ](https://web.archive.org/web/20081011034025/http://www.igda.org/wiki/GDC_2007_-_Tools_Roundtable_Notes)
 
 ------


### PR DESCRIPTION
* add roundtable notes from Paul Haile GDC 2018;
* sort 'sessions' page to show notes from newest to oldest;
* fix links in 2014 GDC notes - use relative links instead of absolute.